### PR TITLE
Changed ISO to be an arbitrary list of values

### DIFF
--- a/src/exif_tag.rs
+++ b/src/exif_tag.rs
@@ -477,7 +477,7 @@ build_tag_enum![
 	(ExposureProgram,             0x8822, INT16U,        Some::<u32>(1),    true,      ExifIFD),
 	(SpectralSensitivity,         0x8824, STRING,        None::<u32>,       true,      ExifIFD),
 	(GPSInfo,                     0x8825, INT32U,        Some::<u32>(1),    true,      IFD0),       // -> GPS Tags: https://exiftool.org/TagNames/GPS.html
-	(ISO,                         0x8827, INT16U,        Some::<u32>(2),    true,      ExifIFD),
+	(ISO,                         0x8827, INT16U,        None::<u32>,       true,      ExifIFD),
 	(OECF,                        0x8828, UNDEF,         None::<u32>,       false,     NO_GROUP),
 	(SensitivityType,             0x8830, INT16U,        Some::<u32>(1),    true,      ExifIFD),
 	(StandardOutputSensitivity,   0x8831, INT32U,        Some::<u32>(1),    true,      ExifIFD),


### PR DESCRIPTION
The exif spec (https://www.cipa.jp/std/documents/download_e.html?DC-008-Translation-2023-E) states in section 4.6.6, Table 9, that "Photographic Sensitivity" (renamed from "ISO speed rating") is an arbitrary number of shorts.

Testing samples from https://github.com/ianare/exif-samples shows that generally, only one value is present. Windows also only recognizes metadata with a single ISO value, so the current implementation produces exif data from which Windows cannot read the ISO value.