### PR TITLE
JPEG optimization and panics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "little_exif_panic"
+name = "little_exif"
 
 version = "0.3.2"
 edition = "2021"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
-name = "little_exif"
+name = "little_exif-panic"
 
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 
 description = """

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "little_exif-panic"
+name = "little_exif_panic"
 
 version = "0.3.2"
 edition = "2021"

--- a/src/endian.rs
+++ b/src/endian.rs
@@ -81,7 +81,9 @@ macro_rules! build_u8conversion
 			)
 			-> $type
 			{
-				assert!(u8_vec.len() == $number_of_bytes);
+				if u8_vec.len() != $number_of_bytes {
+					panic!("Mangled EXIF data encountered!")
+				}
 				match *endian
 				{
 					Endian::Little => <paste!{[<$type>]}>::from_le_bytes(u8_vec[0..$number_of_bytes].try_into().unwrap()),
@@ -117,7 +119,9 @@ macro_rules! build_u8conversion
 			)
 			-> Vec<$type>
 			{
-				assert!(u8_vec.len() % $number_of_bytes == 0);
+				if u8_vec.len() % $number_of_bytes != 0 {
+    panic!("Mangled EXIF data encountered!")
+}
 
 				let mut result: Vec<$type> = Vec::new();
 
@@ -170,7 +174,9 @@ impl U8conversion<String> for String
 	)
 	-> String
 	{
-		assert!(u8_vec.len() % 1 == 0);
+		if u8_vec.len() % 1 != 0 {
+			panic!("Mangled EXIF data encountered!")
+		}
 
 		let mut result = String::new();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,8 +9,8 @@
 //! # Usage
 //! ## Write EXIF data
 //! ```no_run
-//! use little_exif::metadata::Metadata;
-//! use little_exif::exif_tag::ExifTag;
+//! use little_exif_panic::metadata::Metadata;
+//! use little_exif_panic::exif_tag::ExifTag;
 //! 
 //! let mut metadata = Metadata::new();
 //! metadata.set_tag(
@@ -21,7 +21,7 @@
 
 #![forbid(unsafe_code)]
 #![crate_type = "lib"]
-#![crate_name = "little_exif"]
+#![crate_name = "little_exif_panic"]
 
 mod general_file_io;
 mod png;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,8 +9,8 @@
 //! # Usage
 //! ## Write EXIF data
 //! ```no_run
-//! use little_exif_panic::metadata::Metadata;
-//! use little_exif_panic::exif_tag::ExifTag;
+//! use little_exif::metadata::Metadata;
+//! use little_exif::exif_tag::ExifTag;
 //! 
 //! let mut metadata = Metadata::new();
 //! metadata.set_tag(
@@ -21,7 +21,7 @@
 
 #![forbid(unsafe_code)]
 #![crate_type = "lib"]
-#![crate_name = "little_exif_panic"]
+#![crate_name = "little_exif"]
 
 mod general_file_io;
 mod png;


### PR DESCRIPTION
**Resolves** #6 
I have no idea *what* exactly is wrong with that image. I traced it and it tries to shove 22 bytes into from_u8_vec_macro<u32> which obviously fails since u32 != 22/4. 
```rust
if let Ok(tag) = ExifTag::from_u16(hex_tag)
			{
				// ...for a SubIFD...
				if let Some(subifd_group) = tag.is_offset_tag()
				{
					// ...perform a recursive call
					let offset = from_u8_vec_macro!(u32, &raw_data, endian) - given_offset;
		
``` 
In this loop the STRING tag, which seems to indeed be valid data for some reason is interpreted as an offset tag instead thus invoking the macro where the assertion fails. Perhaps this is some unhandled case of metadata structure from a camera manufacturer.

Windows explorer also can't edit the Strings in that image so i consider that a mangled metadata case. We panic instead of assert so that it can be caught in runtime when used a dependency. I consider this a reasonable workaround for now.

**Partially fixes** #7 
Impoves performance of parsing the JPEG file to seek and remove APP1 segment. 
