### PR TITLE
Fix PNG metadata stripping, also remove eXIf and iTXt XMP chunks, add support for cICP chunks

### DIFF
--- a/src/png.rs
+++ b/src/png.rs
@@ -476,9 +476,10 @@ clear_metadata
 			},
 
 			_ => {
-				// In any other case, 
-				seek_counter += chunk.length() as usize + 12;
-				cursor.seek(std::io::SeekFrom::Current(chunk.length() as i64 + 12))?;
+				// In any other case, skip this chunk and continue with the 
+				// next one after adjusting the cursor and the seek counter
+				cursor.seek(std::io::SeekFrom::Current(12 + chunk.length() as i64))?;
+				seek_counter = cursor.position();
 				continue;
 			}
 		}

--- a/src/png.rs
+++ b/src/png.rs
@@ -426,42 +426,6 @@ clear_metadata
 				cursor.seek(std::io::SeekFrom::Current(12 + chunk.length() as i64))?;
 			},
 
-			"iTXt" => {
-				// Skip chunk length and type (4+4 Bytes)
-				cursor.seek(std::io::SeekFrom::Current(4+4))?;
-
-				// Read chunk data into buffer for checking that this is the
-				// correct chunk to delete
-				let mut iTXt_chunk_data = vec![0u8; chunk.length() as usize];
-
-				if cursor.read(&mut iTXt_chunk_data).unwrap() != chunk.length() as usize
-				{
-					return io_error!(Other, "Could not read chunk data");
-				}
-
-				// Compare to the "XML:com.adobe.xmp" string constant
-				let mut correct_iTXt_chunk = true;
-				for i in 0..XML_COM_ADOBE_XMP.len()
-				{
-					if iTXt_chunk_data[i] != XML_COM_ADOBE_XMP[i]
-					{
-						correct_iTXt_chunk = false;
-						break;
-					}
-				}
-
-				// Skip the CRC as it is not important at this point
-				cursor.seek(std::io::SeekFrom::Current(4))?;
-
-				// If this is not the correct iTXt chunk, ignore current
-				// (wrong) iTXt chunk and continue with next chunk
-				if !correct_iTXt_chunk
-				{
-					seek_counter = cursor.position();
-					continue;
-				}
-			},
-
 			"iTXt" | "zTXt" => {
 				// Skip chunk length and type (4+4 Bytes)
 				cursor.seek(std::io::SeekFrom::Current(4+4))?;

--- a/src/png_chunk.rs
+++ b/src/png_chunk.rs
@@ -100,8 +100,8 @@ build_png_chunk_type_enum![
 
     (cHRM,  false,      false,      BEFORE_PLTE_AND_IDAT),
     (gAMA,  false,      false,      BEFORE_PLTE_AND_IDAT),
-    (iCCP,  false,      false,      BEFORE_PLTE_AND_IDAT),
     (cICP,  false,      false,      BEFORE_PLTE_AND_IDAT),
+    (iCCP,  false,      false,      BEFORE_PLTE_AND_IDAT),
     (sBIT,  false,      false,      BEFORE_PLTE_AND_IDAT),
     (sRGB,  false,      false,      BEFORE_PLTE_AND_IDAT),
 

--- a/src/png_chunk.rs
+++ b/src/png_chunk.rs
@@ -101,6 +101,7 @@ build_png_chunk_type_enum![
     (cHRM,  false,      false,      BEFORE_PLTE_AND_IDAT),
     (gAMA,  false,      false,      BEFORE_PLTE_AND_IDAT),
     (iCCP,  false,      false,      BEFORE_PLTE_AND_IDAT),
+    (cICP,  false,      false,      BEFORE_PLTE_AND_IDAT),
     (sBIT,  false,      false,      BEFORE_PLTE_AND_IDAT),
     (sRGB,  false,      false,      BEFORE_PLTE_AND_IDAT),
 


### PR DESCRIPTION
There were a couple logic issues in `clear_metadata()` for PNGs:

1. Everything was off by 8 bytes (the length of the PNG file header) because the `seek_counter` was initialised at 8 bytes, but the `cursor` started at 0.
2. When reading a chunk to determine if it should be removed, the cursor remained at the end after truncation, making it out of sync with `seek_counter` and the actual data `Vec` being modified. (this bug might also exist in other formats' `clear_metadata()`, but I haven't checked)

Once these bugs were fixed, stripping `eXIf` chunks and `iTXt` chunks with the keyword `XML:com.adobe.xmp` functionality was added.

There could be more metadata to remove here, namely other kinds of `iTXt` and `zTXt` chunks, and `tEXt` chunks, but I will refrain from changing that here.

fixes: #55

*minor whitespace changes by editor*
