### PR TITLE
Replace prints with logging in library

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ exclude = [
 crc = "3.2.1"
 paste = "1.0.15"
 miniz_oxide = "0.8.0"
+log = "0.4"
 
 [[test]]
 name = "tests"

--- a/src/ifd/mod.rs
+++ b/src/ifd/mod.rs
@@ -10,6 +10,8 @@ use std::io::Read;
 use std::io::Seek;
 use std::vec;
 
+use log::warn;
+
 use crate::endian::*;
 use crate::exif_tag::decode::decode_tag_with_format_exceptions;
 use crate::exif_tag::ExifTag;
@@ -408,7 +410,7 @@ ImageFileDirectory
 				}
 				else
 				{
-					eprintln!("WARNING: Can't decode thumbnail! The ThumbnailOffset and ThumbnailLength tags are expected to contain exactly 1 INT32U value. However, they have {} and {} values.", offset.len(), length.len());
+					warn!("Can't decode thumbnail! The ThumbnailOffset and ThumbnailLength tags are expected to contain exactly 1 INT32U value. However, they have {} and {} values.", offset.len(), length.len());
 				}
 
 				// Restore backup position

--- a/src/ifd/set.rs
+++ b/src/ifd/set.rs
@@ -1,6 +1,8 @@
 // Copyright © 2024 Tobias J. Prisching <tobias.prisching@icloud.com> and CONTRIBUTORS
 // See https://github.com/TechnikTobi/little_exif#license for licensing details
 
+use log::warn;
+
 use crate::exif_tag::ExifTag;
 
 use super::ImageFileDirectory;
@@ -22,7 +24,7 @@ ImageFileDirectory
 	{
 		if input_tag.get_group() != self.ifd_type
 		{
-			eprintln!("Warning: The tag {:?} is set in an IFD that has not a matching group.", input_tag);
+			warn!("The tag {:?} is set in an IFD that has not a matching group.", input_tag);
 		}
 		self.tags.retain(|tag| tag.as_u16() != input_tag.as_u16());
 		self.tags.push(input_tag);

--- a/src/metadata/mod.rs
+++ b/src/metadata/mod.rs
@@ -13,6 +13,9 @@ use std::io::Read;
 use std::io::Seek;
 use std::io::Write;
 
+use log::error;
+use log::warn;
+
 use crate::endian::*;
 use crate::general_file_io::io_error;
 use crate::general_file_io::EXIF_HEADER;
@@ -98,15 +101,15 @@ Metadata
 			}
 			else
 			{
-				eprintln!("{}", decoding_result.err().unwrap());
+				error!("{}", decoding_result.err().unwrap());
 			}
 		}
 		else
 		{
-			eprintln!("Error during decoding: {:?}", raw_pre_decode_general.err().unwrap());
+			error!("Error during decoding: {:?}", raw_pre_decode_general.err().unwrap());
 		}
 
-		eprintln!("WARNING: Can't read metadata - Create new & empty struct");
+		warn!("Can't read metadata - Create new & empty struct");
 		return Ok(Metadata::new());
 	}
 

--- a/src/png.rs
+++ b/src/png.rs
@@ -12,6 +12,7 @@ use std::path::Path;
 
 use crc::Crc;
 use crc::CRC_32_ISO_HDLC;
+use log::warn;
 use miniz_oxide::deflate::compress_to_vec_zlib;
 use miniz_oxide::inflate::decompress_to_vec_zlib;
 
@@ -226,7 +227,7 @@ get_next_chunk_descriptor
 	}
 	else
 	{
-		eprintln!("Warning: Unknown PNG chunk name: {}", chunk_name.unwrap());
+		warn!("Unknown PNG chunk name: {}", chunk_name.unwrap());
 		return Ok(png_chunk_result.err().unwrap());
 	}
 }

--- a/src/webp/file.rs
+++ b/src/webp/file.rs
@@ -8,6 +8,8 @@ use std::io::Seek;
 use std::io::SeekFrom;
 use std::path::Path;
 
+use log::debug;
+
 use crate::endian::*;
 use crate::metadata::Metadata;
 use crate::u8conversion::*;
@@ -394,7 +396,7 @@ convert_to_extended_format
 	let (width, height) = match first_chunk.descriptor().header().as_str()
 	{
 		"VP8" 
-			=> {println!("VP8 !"); todo!()},
+			=> {debug!("VP8 !"); todo!()},
 		"VP8L"
 			=> get_dimension_info_from_vp8l_chunk(first_chunk.payload()),
 		_ 

--- a/src/webp/vec.rs
+++ b/src/webp/vec.rs
@@ -6,6 +6,8 @@ use std::io::Read;
 use std::io::Seek;
 use std::io::Write;
 
+use log::debug;
+
 use crate::general_file_io::EXIF_HEADER;
 use crate::metadata::Metadata;
 use crate::util::insert_multiple_at;
@@ -380,7 +382,7 @@ convert_to_extended_format
 	let (width, height) = match first_chunk.descriptor().header().as_str()
 	{
 		"VP8" 
-			=> {println!("VP8 !"); todo!()},
+			=> {debug!("VP8 !"); todo!()},
 		"VP8L"
 			=> get_dimension_info_from_vp8l_chunk(first_chunk.payload()),
 		_ 


### PR DESCRIPTION
Libraries generally shouldn't print things to stdio themselves, as it could be unexpected by the consumer. The `log` crate provides a flexible way for consumers of the library to collect and emit the errors, warnings, and other messages.
