### PR TITLE
Fix debug-level logging and add documentation on how to use it

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,35 @@ metadata.set_tag(
 metadata.write_to_vec(&mut image_vector, file_type)?;
 ```
 
+## Logging
+
+This library uses the [`log`](https://crates.io/crates/log) crate for various levels of logging.
+
+### Setup
+
+To enable this logging, you will need to initialize logger, such as [`env_logger`](https://docs.rs/env_logger/latest/env_logger/):
+
+```bash
+cargo add env_logger
+```
+
+```rust
+fn main() {
+    env_logger::init();
+}
+```
+
+### Usage
+
+In `env_logger`, you can view `little_exif`'s debug-level logs, for example, by setting the `RUST_LOG` env var:
+```bash
+env RUST_LOG=debug cargo run
+```
+
+For other log levels, see [`env_logger`'s documentation](https://docs.rs/env_logger/latest/env_logger/).
+
+You do not need to use `env_logger` for logging, you may use any logger of your choice.
+
 ## FAQ
 
 ### I tried writing the ImageDescription tag on a JPEG file, but it does not show up. Why?

--- a/src/heif/boxes/iso.rs
+++ b/src/heif/boxes/iso.rs
@@ -4,8 +4,6 @@
 use std::io::Read;
 use std::io::Seek;
 
-use crate::debug_println;
-
 use crate::heif::box_header::BoxHeader;
 use crate::heif::boxes::GenericIsoBox;
 use crate::heif::boxes::ParsableIsoBox;
@@ -31,7 +29,7 @@ IsoBox
     )
     -> Result<IsoBox, std::io::Error> 
     {
-        debug_println!("Constructing generic ISO box for type {:?}", header.get_box_type());
+        log::debug!("Constructing generic ISO box for type {:?}", header.get_box_type());
 
         // Check if this box is the last in the file
         // See also: ISO/IEC 14496-12:2015, § 4.2

--- a/src/heif/boxes/item_info.rs
+++ b/src/heif/boxes/item_info.rs
@@ -4,8 +4,6 @@
 use std::io::Read;
 use std::io::Seek;
 
-use crate::debug_println;
-
 use crate::endian::Endian;
 use crate::u8conversion::U8conversion;
 use crate::u8conversion::to_u8_vec_macro;
@@ -82,7 +80,7 @@ ItemInfoEntryBox
         let mut additional_data = vec![0u8; data_left_to_read];
         cursor.read_exact(&mut additional_data)?;
 
-        debug_println!("ID: {}, Name: {}", item_id, item_name);
+        log::debug!("ID: {}, Name: {}", item_id, item_name);
 
         return Ok(ItemInfoEntryBox {
             header,

--- a/src/heif/boxes/item_location.rs
+++ b/src/heif/boxes/item_location.rs
@@ -4,7 +4,6 @@
 use std::io::Read;
 use std::io::Seek;
 
-use crate::debug_println;
 use crate::endian::Endian;
 use crate::u8conversion::U8conversion;
 use crate::u8conversion::to_u8_vec_macro;
@@ -241,7 +240,7 @@ ItemLocationEntry
             extents
         };
 
-        debug_println!("{:?}", entry);
+        log::debug!("{:?}", entry);
 
         return Ok(entry);
     }

--- a/src/heif/boxes/mod.rs
+++ b/src/heif/boxes/mod.rs
@@ -4,8 +4,6 @@
 use std::io::Read;
 use std::io::Seek;
 
-use crate::debug_println;
-
 use super::box_type::BoxType;
 use super::box_header::BoxHeader;
 
@@ -73,7 +71,7 @@ read_next_box
 {
     let header = BoxHeader::read_box_header(cursor)?;
 
-    debug_println!("{:?}", header);
+    log::debug!("{:?}", header);
 
     return read_box_based_on_header(cursor, header);
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -290,27 +290,6 @@ where T: Copy
     vec.truncate(new_vec_len);
 }
 
-#[macro_export]
-macro_rules! debug_println 
-{
-    (
-        $($arg:tt)*
-    ) 
-    => 
-    (
-        /*
-        #[cfg(debug_assertions)] 
-        {
-            print!("LITTLE EXIF DEBUG: ");
-            println!($($arg)*);
-        }
-        */
-
-        ()
-    );
-}
-
-
 /*
 /// Inserts a slice into a vector at a given offset, shifting elements 
 /// starting at the offset towards the end.


### PR DESCRIPTION
This PR replaces the in-house `debug_println!` macro with `log::debug!` macro, since the `log` crate is already a dependency of this library.

I also added documentation so users of this library know how to interact/enable `little_exif`'s logging in their own applications.

This type of logging:
![image](https://github.com/user-attachments/assets/c0b36062-bfa6-41e0-864d-fb13f0853ca4)

Looks like this now:
![image](https://github.com/user-attachments/assets/36ee7e34-4546-43a0-b0f6-7156a7436bf2)
