### PR TITLE
Add `as_u8_vec` for heif images

### DIFF
--- a/src/heif/mod.rs
+++ b/src/heif/mod.rs
@@ -103,16 +103,15 @@ file_write_metadata
     return Ok(());
 }
 
+/// Encodes the given metadata into a vector of bytes that can be used as
+/// an exif box in an HEIF file.
+pub(crate) fn as_u8_vec(general_encoded_metadata: &Vec<u8>) -> Vec<u8> {
+    let mut data_buffer: Vec<u8> = Vec::new();
+    data_buffer.extend(EXIF_HEADER.iter());
+    data_buffer.extend(general_encoded_metadata.iter());
+    return data_buffer;
+}
 
-
-pub(crate) fn
-clear_metadata
-(
-    file_buffer: &mut Vec<u8>
-)
--> Result<(), std::io::Error>
-{
-    let mut cursor    = Cursor::new(file_buffer);
     let mut container = HeifContainer::construct_from_cursor_unboxed(&mut cursor)?;
 
     return container.generic_clear_metadata(cursor.get_mut());

--- a/src/metadata/metadata_io.rs
+++ b/src/metadata/metadata_io.rs
@@ -323,10 +323,10 @@ Metadata
 				=>  png::as_u8_vec(&general_encoded_metadata, as_zTXt_chunk),
 			FileExtension::JPEG 
 				=>  jpg::as_u8_vec(&general_encoded_metadata),
-			FileExtension::WEBP 
-				=> webp::as_u8_vec(&general_encoded_metadata),
-			_
-				=> Vec::new(),
+            FileExtension::HEIF => heif::as_u8_vec(&general_encoded_metadata),
+            _ => {
+                unimplemented!()
+            }
 		})
 	}
 


### PR DESCRIPTION
This is a simple implementation of  `as_u8_vec`  for HEIF images that happens to also work for avif. One of the thing is that, when I had the length prefix it breaks the metadata reading for exiftool and i don't know why.

So I purposly not added it because whenever I add it, I fail to parse the exif on exiftool.

Not sure if you have any pointers on how to improve this.

