### PR TITLE
cargo: update MSRV accordingly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "little_exif"
 
 version = "0.6.13"
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.80"
 
 description = """
 The only pure Rust crate with true read *and* write support for EXIF data, 


### PR DESCRIPTION
Since commit a4c6304 (0.6.4), this crate is using seek_relative(), which was added in Rust 1.80.0 per [1]. Adapt the minimum supported rust version for upcoming releases.

[1] https://doc.rust-lang.org/beta/std/io/trait.Seek.html#method.seek_relative