### PR TITLE
Fix file corruption when writing meta to heif file without an iref box

### DIFF
--- a/src/heif/boxes/meta.rs
+++ b/src/heif/boxes/meta.rs
@@ -111,14 +111,15 @@ MetaBox
     create_new_item_reference_box_if_none_exists_yet
     (
         &mut self
-    )
+    ) -> usize
     {
         if self.get_item_reference_box().is_some()
         {
-            return;
+            return 0;
         }
 
         let new_iref_box = ItemReferenceBox::new();
+        let new_iref_box_size = new_iref_box.get_header().get_box_size();
 
         let index = self.other_boxes
             .iter()
@@ -126,6 +127,8 @@ MetaBox
             .unwrap();
         
         self.other_boxes.insert(index, Box::new(new_iref_box));
+
+        return new_iref_box_size;
     }
 }
 

--- a/src/heif/container.rs
+++ b/src/heif/container.rs
@@ -347,8 +347,9 @@ HeifContainer
             // Where to put the new exif area
             let new_exif_start = self.get_start_address_for_new_exif_area();
 
-            // If there is no iref box yet, create one so we can find one
-            self.get_meta_box_mut()
+            // If there is no iref box yet, create one so we can find one, 
+            // and get the size delta of the new box for extents
+            let mut iref_size_delta = self.get_meta_box_mut()
                 .create_new_item_reference_box_if_none_exists_yet();
 
             // Acquire the item location, the item information and the item 
@@ -403,7 +404,7 @@ HeifContainer
                 new_iloc_id, 
                 "Exif"
             );
-            let               iref_size_delta  = iref.create_new_single_item_reference_box(
+            iref_size_delta += iref.create_new_single_item_reference_box(
                 "cdsc".to_string(), // TODO: Check if this is always this type?
                 new_iloc_id, 
                 vec![1]             // TODO: Check if this is always item #1?


### PR DESCRIPTION
`create_new_single_item_reference_box`  only return box size delta, if iref box create by `create_new_item_reference_box_if_none_exists_yet`,  cause extents length is 18 bytes shorter than expected, which results in file corruption.